### PR TITLE
fix(login): ignore timeout error in commit 69899c0f795ebc518bcdd151e758dae973ad1cc0

### DIFF
--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -51,10 +51,9 @@ func (h *IpgwHandler) Login(account *model.Account) error {
 
 	// 修复首次登录失败问题
 	resp, err = h.client.Get("http://198.18.0.1")
-	if err != nil {
-		return err
+	if err == nil {
+	    defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
 
 	if account.Cookie != "" {
 		body, err = h.loginCookie(account.Cookie) // 通过cookie登录


### PR DESCRIPTION
实在抱歉，之前的开pr草率了，因为之前一直用的无线校园网，今天连学校有线网络的时候才意识到有问题

原因如下：
我发现有线校园网不会自动重定向http请求，在有线校园网下 commit 69899c0f795ebc518bcdd151e758dae973ad1cc0 对不存在服务器发出请求一定会timeout直接返回err，导致后面的登录流程不能进行

这个pr改为不返回err，但是连有线网会出现等待timeout几秒的副作用，所以只是一个workaround，不知道有没有更好的解决方法
