### PR TITLE
[fix] 修复新版本校园网网关下日志、设备信息无法正常获取的问题

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -149,7 +149,7 @@ var (
 			password := ctx.String("password")
 			if password != "" {
 				if err = account.SetPassword(ctx.String("password"), []byte(ctx.String("secret"))); err != nil {
-					return fmt.Errorf("fail to set account:\n\t'%s' not found", username)
+					return fmt.Errorf("fail to set password:\n\t'%v'", err)
 				}
 			}
 

--- a/pkg/cmd/info.go
+++ b/pkg/cmd/info.go
@@ -128,7 +128,7 @@ func (i *infoPrinter) PrintDevices() {
 		return
 	}
 	for _, device := range devices {
-		console.InfoF("\tNo.%d\t%s\t%s\t%s\n", device.ID, device.IP, device.StartTime, device.SID)
+		console.InfoF("\tNo.%d\t%s\t%s\t%8s\t%s\n", device.ID, device.IP, device.StartTime, device.SID, device.Stage)
 	}
 }
 
@@ -154,7 +154,7 @@ func (i *infoPrinter) PrintLog(page int) {
 		return
 	}
 	for _, record := range records {
-		console.InfoF("\t%s - %s\t%s\t%s\n", record.StartTime, record.EndTime, record.IP, record.Traffic)
+		console.InfoF("\t%s - %s\t%s\t%10s\t%s\n", record.StartTime, record.EndTime, record.IP, record.Traffic, record.UsedDuration)
 	}
 }
 

--- a/pkg/handler/dashboard.go
+++ b/pkg/handler/dashboard.go
@@ -115,7 +115,7 @@ func (d *DashboardHandler) GetPackage() (*Package, error) {
 		return nil, err
 	}
 
-	infos, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="3">(.+?)</td><td data-col-seq="4">(.+?)</td><td data-col-seq="6">(.+?)</td><td data-col-seq="7">(.+?)</td></tr>`), body)
+	infos, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="3">(.+?)</td><td data-col-seq="4">(.+?)</td><td data-col-seq="6">(.+?)</td><td data-col-seq="7">(.+?)</td>`), body)
 	if len(infos) < 1 {
 		return nil, errors.New("fail to get package info")
 	}
@@ -207,7 +207,7 @@ func (d *DashboardHandler) GetUsageRecords(page int) ([]UsageRecord, error) {
 		return []UsageRecord{}, errors.New("error occurs when parsing usage log page")
 	}
 
-	hs, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="1">(.+?)</td><td data-col-seq="2">(.+?)</td><td data-col-seq="5">(.+?)</td><td data-col-seq="10">.+?</td><td data-col-seq="12">.+?</td><td style="display: none;" data-col-seq="14">.+?</td><td data-col-seq="15">(.+?)</td><td style="display: none;" data-col-seq="16">.+?</td><td data-col-seq="17">(.+?)</td><td data-col-seq="18">.+?</td></tr>`), body)
+	hs, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="0">.+?</td><td data-col-seq="1">(.+?)</td><td data-col-seq="2">(.+?)</td><td data-col-seq="5">(.+?)</td><td data-col-seq="10">.+?</td><td data-col-seq="12">.+?</td><td style="display: none;" data-col-seq="16">.+?</td><td data-col-seq="17">(.+?)</td><td style="display: none;" data-col-seq="18">.+?</td><td data-col-seq="19">(.+?)</td><td data-col-seq="20">.+?</td>`), body)
 	result := make([]UsageRecord, len(hs))
 	for i, h := range hs {
 		result[i] = UsageRecord{h[1], h[2], h[3], h[4], h[5]}

--- a/pkg/handler/dashboard.go
+++ b/pkg/handler/dashboard.go
@@ -140,6 +140,7 @@ type Device struct {
 	ID        int
 	IP        string
 	StartTime string
+	Stage     string
 	SID       string
 }
 
@@ -148,10 +149,10 @@ func (d *DashboardHandler) GetDevice() ([]Device, error) {
 	if err != nil {
 		return []Device{}, err
 	}
-	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="9">.+?</td>`), body)
+	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="7">(.+?)</td><td data-col-seq="9">.+?</td>`), body)
 	result := make([]Device, len(ds))
 	for i, device := range ds {
-		result[i] = Device{i, device[2], device[3], device[1]}
+		result[i] = Device{i, device[2], device[3], device[4], device[1]}
 	}
 	return result, nil
 }

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -1,6 +1,9 @@
 package model
 
-import "github.com/neucn/ipgw/pkg/utils"
+import (
+	"fmt"
+	"github.com/neucn/ipgw/pkg/utils"
+)
 
 type Config struct {
 	DefaultAccount string     `json:"default_account"`
@@ -8,6 +11,11 @@ type Config struct {
 }
 
 func (c *Config) AddAccount(username, password, secret string) error {
+	for _, account := range c.Accounts {
+		if account.Username == username {
+			return fmt.Errorf("account %s already exists \n", username)
+		}
+	}
 	encryptedPassword, err := utils.Encrypt([]byte(password), []byte(secret))
 	if err != nil {
 		return err


### PR DESCRIPTION
1.  新版本网关下页面格式改变导致正则不能够正常获取信息

2.   对于重复添加账号进行判断

3.  添加显示设备当前套餐阶段状态