### PR TITLE
Better error information & A possible better way to enter password.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/term v0.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,10 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.24.0 h1:Mh5cbb+Zk2hqqXNO7S1iTjEphVL+jb8ZWaqh/g+JWkM=
+golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/neucn/ipgw/pkg/console"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/term"
 )
 
 var (
@@ -39,8 +41,9 @@ var (
 			},
 			&cli.StringFlag{
 				Name:     "password",
+				Value:	  "",
 				Aliases:  []string{"p"},
-				Required: true,
+				Required: false,
 				Usage:    "`password` for pass.neu.edu.cn",
 			},
 			&cli.StringFlag{
@@ -60,6 +63,14 @@ var (
 			}
 			username := ctx.String("username")
 			password := ctx.String("password")
+			if password == "" {
+			   fmt.Print("Enter Password: ")
+		           bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+			   if err != nil {
+			      return err
+			   }
+			    password = string(bytePassword)
+			}
 			if err = store.Config.AddAccount(
 				username,
 				password,

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"errors"
 
 	"github.com/neucn/ipgw/pkg/model"
 	"github.com/neucn/ipgw/pkg/utils"
@@ -59,6 +60,22 @@ func (h *IpgwHandler) Login(account *model.Account) error {
 
 	if err != nil {
 		return err
+	}
+
+	type LoginResponse struct {
+	     Code int `json:"code"`
+	     Message string `json:"message"`
+	     Redirect string
+	     ID string
+	}
+	var loginResponse LoginResponse
+	parseLoginResponseErr := json.Unmarshal([]byte(body), &loginResponse)
+	if parseLoginResponseErr != nil {
+	   return parseLoginResponseErr
+	}
+
+	if loginResponse.Code != 0 {
+	   return errors.New(loginResponse.Message)
 	}
 
 	if strings.Contains(body, "Arrearage users") {


### PR DESCRIPTION
- 更好的错误信息显示

  之前：
  ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        unknown reason
  ```

  现在：
  显示来自 `https://ipgw.neu.edu.cn/v1/srun_portal_sso?ac_id=1&ticket=ST-xxxxxxxx-xxxxxxxxxxxxxxxxxx-tpass` 的响应 json 的 `message`
   ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        E2606: User is disabled.
  ```

- 一种可能更好的输入密码的方式。

  之前：（需要密码，该密码可能存在于 bash/zsh/... 历史记录中）：
  ```shell
  $ ipgw config account add -u xxxxxxx -p xxx...xxx # 可能不安全
  ```
  现在：
  ```shell
  $ ipgw config account add -u xxxxxxx
  Enter Password: # 输入时不回显
  ```

---

- Better error information

  previous:
  ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        unknown reason
  ```
  
  current:
  show `message` from response json of `https://ipgw.neu.edu.cn/v1/srun_portal_sso?ac_id=1&ticket=ST-xxxxxxxx-xxxxxxxxxxxxxxxxxxxx-tpass`
   ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        E2606: User is disabled.
  ```

- A possible better way to enter password.

  previous (password is required which may exist in the bash/zsh/... history):
  ```shell
  $ ipgw config account add -u xxxxxxx -p xxx...xxx # Potentially unsafe
  ```

  current:
  ```shell
  $ ipgw config account add -u xxxxxxx
  Enter Password: # type in without echo
  ```