### PR TITLE
feat: more detailed error messages

### DIFF
--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -61,8 +61,20 @@ func (h *IpgwHandler) Login(account *model.Account) error {
 		return err
 	}
 
-	if strings.Contains(body, "Arrearage users") {
-		return fmt.Errorf("overdue")
+	type LoginResponse struct {
+		Code     int    `json:"code"`
+		Message  string `json:"message"`
+		Redirect string
+		ID       string
+	}
+	var loginResponse LoginResponse
+	parseLoginResponseErr := json.Unmarshal([]byte(body), &loginResponse)
+	if parseLoginResponseErr != nil {
+		return parseLoginResponseErr
+	}
+
+	if loginResponse.Code != 0 {
+		return errors.New(loginResponse.Message)
 	}
 
 	return h.ParseBasicInfo() // 解析信息


### PR DESCRIPTION
- 更好的错误信息显示

  之前：
  ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        unknown reason
  ```

  现在：
  显示来自 `https://ipgw.neu.edu.cn/v1/srun_portal_sso?ac_id=1&ticket=ST-xxxxxxxx-xxxxxxxxxxxxxxxxxx-tpass` 的响应 json 的 `message`
   ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        E2606: User is disabled.
  ```
---

- Better error information

  previous:
  ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        unknown reason
  ```
  
  current:
  show `message` from response json of `https://ipgw.neu.edu.cn/v1/srun_portal_sso?ac_id=1&ticket=ST-xxxxxxxx-xxxxxxxxxxxxxxxxxxxx-tpass`
   ```shell
  $ ipgw login -u xxxxxxx
  login failed:
        E2606: User is disabled.
  ```
